### PR TITLE
gpcoffgen: fix return-type errors

### DIFF
--- a/gputils/libgputils/gpcoffgen.c
+++ b/gputils/libgputils/gpcoffgen.c
@@ -310,7 +310,7 @@ gp_coffgen_move_reserve_section_symbols(gp_object_t *Object, gp_section_t *Secti
   gp_symbol_t *symbol;
 
   if (Object == NULL) {
-    return NULL;
+    return;
   }
 
   /* Move all symbols for the section into dead list. */
@@ -336,7 +336,7 @@ gp_coffgen_del_section_symbols(gp_object_t *Object, gp_section_t *Section)
   gp_symbol_t *symbol;
 
   if (Object == NULL) {
-    return NULL;
+    return;
   }
 
   /* Remove all symbols for the section. */


### PR DESCRIPTION
Fixes

```
gpcoffgen.c:313:5: error: void function 'gp_coffgen_move_reserve_section_symbols' should not return a value [-Wreturn-type]
    return NULL;
    ^      ~~~~
gpcoffgen.c:339:5: error: void function 'gp_coffgen_del_section_symbols' should not return a value [-Wreturn-type]
    return NULL;
    ^      ~~~~
2 errors generated.
```
